### PR TITLE
Ignore errors.txt, log.txt, and traceback.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+errors.txt
+log.txt
+traceback.txt
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db


### PR DESCRIPTION
These files really shouldn't be in the repository. It might be a good idea to also add `tmp/` to .gitignore. I wasn't sure whether or not that directory is needed.